### PR TITLE
README.md: removed `encode a multipass token step` to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,7 @@ Make sure "Accounts are required" or "Accounts are optional" is selected and Mul
   var multipassify = new Multipassify("SHOPIFY MULTIPASS SECRET");
 
   // Create your customer data hash
-  var customerData = { email: 'test@example.com', remote_ip:'USERS IP ADDRESS', return_to:"http://some.url"};
-
-  // Encode a Multipass token
-  var token = multipassify.encode(customerData);
+  var customerData = { email: 'test@example.com', remote_ip:'USERS IP ADDRESS', return_to:"http://some.url"};;
 
   // Generate a Shopify multipass URL to your shop
   var url = multipassify.generateUrl(customerData, "yourstorename.myshopify.com");


### PR DESCRIPTION
The README.md consists of the below code which leads to confusion. The variable `token` is not used anywhere in the subsequent piece of code. 

```
 // Encode a Multipass token
var token = multipassify.encode(customerData);
 ```